### PR TITLE
Fixed symbolic link to doc

### DIFF
--- a/visualizer/radiomediumactivity/doc
+++ b/visualizer/radiomediumactivity/doc
@@ -1,1 +1,1 @@
-../../docs/visualizer/physicalmediumactivity/
+../../docs/visualizer/radiomediumactivity/


### PR DESCRIPTION
In commit 23178b43021f0ff5c68ce2803afea1d88bcbb6ed, `physicalmediumactivity` was renamed to `radiomediumactivity`. The link to the corresponding docs was not updated accordingly. This PR fixes the broken symbolic link.